### PR TITLE
fix get_parent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,13 @@ default_language_version:
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.3.4'
+    rev: v0.4.3
     hooks:
+    # Run the linter.
     - id: ruff
-  - repo: https://github.com/psf/black
-    rev: 24.3.0
-    hooks:
-    - id: black
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,8 @@ warn_required_dynamic_aliases = true
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+lint.select = [
+    "I",  # isort formatting.
+]

--- a/src/xarray_ome_ngff/core.py
+++ b/src/xarray_ome_ngff/core.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
-from pydantic import BaseModel
-from typing import Union
+
+import os
+from typing import Generator, Union
 
 import pint
+import zarr
+from pydantic import BaseModel
+from zarr.errors import ContainsArrayError, GroupNotFoundError, _BaseZarrError
 
 ureg = pint.UnitRegistry()
 
@@ -17,3 +21,44 @@ class CoordinateAttrs(BaseModel):
 
 JSON = Union[dict[str, "JSON"], list["JSON"], str, int, float, bool, None]
 NGFF_VERSIONS = ("0.4",)
+
+
+class GroupUnreachableError(GroupNotFoundError):
+    _msg = "group could not found because it is outside the Zarr hierarchy"
+
+
+def get_parent(node: zarr.Group | zarr.Array) -> zarr.Group:
+    """
+    Get the hierarchically precedent (i.e., parent) node of a Zarr array or group.
+    """
+    # not all zarr stores have a path attribute, namely memorystore
+    if hasattr(node.store, "path"):
+        store_path = node.store.path
+        if node.path == "":
+            new_full_path, new_node_path = os.path.split(os.path.split(store_path)[0])
+        else:
+            full_path, _ = os.path.split(os.path.join(store_path, node.path))
+            new_full_path, new_node_path = os.path.split(full_path)
+        return zarr.open_group(
+            type(node.store)(new_full_path), path=new_node_path, mode="r"
+        )
+    else:
+        if node.path == "":
+            # there is no parent to find, because we are at the root of the hierarchy.
+            raise GroupUnreachableError()
+        try:
+            group_path = os.path.split(node.path)[0]
+            return zarr.open_group(store=node.store, path=group_path, mode="r")
+        except ContainsArrayError as e:
+            raise GroupNotFoundError(group_path) from e
+
+
+def iter_parents(node: zarr.Group) -> Generator[zarr.Group, None]:
+    node_current = node
+    while True:
+        try:
+            parent = get_parent(node_current)
+            yield parent
+            node_current = parent
+        except GroupNotFoundError:
+            return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from zarr.storage import DirectoryStore, MemoryStore
+
+
+@pytest.fixture(scope="function")
+def store(request, tmpdir):
+    if request.param == "memory_store":
+        return MemoryStore()
+    elif request.param == "directory_store":
+        return DirectoryStore(str(tmpdir))
+    else:
+        assert False

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from xarray_ome_ngff.core import get_parent, iter_parents
+
+if TYPE_CHECKING:
+    from typing import Literal
+import numpy as np
+import pytest
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
+from zarr import DirectoryStore, MemoryStore, open_array, open_group
+from zarr.errors import GroupNotFoundError
+
+
+@pytest.mark.parametrize("node_type", ("array", "group"))
+@pytest.mark.parametrize(
+    "store", ("directory_store", "memory_store"), indirect=("store",)
+)
+def test_ascend_once(
+    node_type: Literal["array", "group"], store: DirectoryStore | MemoryStore
+) -> None:
+    tree_flat: dict[str, ArraySpec | GroupSpec] = {
+        "/node": GroupSpec(attributes={"target": True})
+    }
+    if node_type == "array":
+        subnode = ArraySpec.from_array(np.arange(10))
+    elif node_type == "group":
+        subnode = GroupSpec()
+    else:
+        assert False
+
+    tree_flat["/node/subnode"] = subnode
+    hierarchy = GroupSpec.from_flat(tree_flat).to_zarr(store, path="/")
+
+    assert get_parent(hierarchy["node/subnode"]).attrs["target"] == True
+
+
+@pytest.mark.parametrize("node_type", ("array", "group"))
+@pytest.mark.parametrize(
+    "store", ("directory_store", "memory_store"), indirect=("store",)
+)
+def test_get_parent_root_node(
+    node_type: Literal["array", "group"], store: DirectoryStore | MemoryStore
+):
+    if node_type == "array":
+        hierarchy = open_array(store=store, path="", shape=(10, 10))
+    elif node_type == "group":
+        hierarchy = open_group(store=store, path="")
+
+    with pytest.raises(GroupNotFoundError):
+        get_parent(hierarchy)
+
+
+import os
+from itertools import accumulate
+
+
+@pytest.mark.parametrize("start_depth", (1, 2, 3))
+@pytest.mark.parametrize(
+    "store", ("directory_store", "memory_store"), indirect=("store",)
+)
+def test_iter_parents(start_depth: int, store: MemoryStore | DirectoryStore):
+    tree_flat = {}
+    for key in accumulate(
+        map(str, range(1, start_depth)), lambda a, b: os.path.join(a, b), initial="/0"
+    ):
+        tree_flat[key] = GroupSpec()
+
+    hierarchy = GroupSpec.from_flat(tree_flat).to_zarr(store, path="")
+    keys = tuple(tree_flat.keys())
+    for key, node in zip(keys[:-1][::-1], iter_parents(hierarchy[keys[-1]])):
+        assert node.path.split("/")[-1] == key.split("/")[-1]


### PR DESCRIPTION
previously, get_parent was untested and would not handle reaching the root of a zarr hierarchy correctly. This PR adds tests and a custom exception for when the end of a hierarchy is reached. Also it adds a generate over the parents of a node.