### PR TITLE
Get parent s3 fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,18 +7,26 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  test:
+    name: py=${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
     steps:
     - uses: actions/checkout@v4
-    - name: Install dependencies
-      shell: "bash -l {0}"
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install Hatch
       run: |
-        pip install poetry
-        poetry install
-    - name: Test
+        python -m pip install --upgrade pip 
+        pip install hatch
+    - name: Set Up Hatch Env
       run: |
-        poetry run pytest
+        hatch env create test.py${{ matrix.python-version }}
+    - name: Run Tests
+      run: |
+        hatch env run --env test.py${{ matrix.python-version }} run

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,28 +32,28 @@ array_wrapper = DaskArrayWrapper(chunks=10)
 arrays = read_multiscale_group(group, array_wrapper=array_wrapper)
 print(arrays)
 """
-{'0': <xarray.DataArray 'array-bb42996937dbff7600e0481e2b1572cc' (c: 2, z: 236,
-                                                            y: 275, x: 271)>
+{'0': <xarray.DataArray 'array-dc1746969a43c4e18b4a861ae8a5b5e5' (c: 2, z: 236,
+                                                            y: 275, x: 271)> Size: 70MB
 dask.array<array, shape=(2, 236, 275, 271), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
 Coordinates:
-  * c        (c) float64 0.0 1.0
-  * z        (z) float64 0.0 0.5002 1.0 1.501 2.001 ... 116.0 116.5 117.0 117.5
-  * y        (y) float64 0.0 0.3604 0.7208 1.081 ... 97.67 98.03 98.39 98.75
-  * x        (x) float64 0.0 0.3604 0.7208 1.081 ... 96.23 96.59 96.95 97.31, '1': <xarray.DataArray 'array-2bfe6d4a6d289444ca93aa84fcb36342' (c: 2, z: 236,
-                                                            y: 137, x: 135)>
+  * c        (c) float64 16B 0.0 1.0
+  * z        (z) float64 2kB 0.0 0.5002 1.0 1.501 ... 116.0 116.5 117.0 117.5
+  * y        (y) float64 2kB 0.0 0.3604 0.7208 1.081 ... 97.67 98.03 98.39 98.75
+  * x        (x) float64 2kB 0.0 0.3604 0.7208 1.081 ... 96.23 96.59 96.95 97.31, '1': <xarray.DataArray 'array-9663bb2b4241268352500eb4e3bef581' (c: 2, z: 236,
+                                                            y: 137, x: 135)> Size: 17MB
 dask.array<array, shape=(2, 236, 137, 135), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
 Coordinates:
-  * c        (c) float64 0.0 1.0
-  * z        (z) float64 0.0 0.5002 1.0 1.501 2.001 ... 116.0 116.5 117.0 117.5
-  * y        (y) float64 0.0 0.7208 1.442 2.162 ... 95.87 96.59 97.31 98.03
-  * x        (x) float64 0.0 0.7208 1.442 2.162 ... 94.42 95.15 95.87 96.59, '2': <xarray.DataArray 'array-80c5fc67c0c57909c0a050656a5ab630' (c: 2, z: 236,
-                                                            y: 68, x: 67)>
+  * c        (c) float64 16B 0.0 1.0
+  * z        (z) float64 2kB 0.0 0.5002 1.0 1.501 ... 116.0 116.5 117.0 117.5
+  * y        (y) float64 1kB 0.0 0.7208 1.442 2.162 ... 95.87 96.59 97.31 98.03
+  * x        (x) float64 1kB 0.0 0.7208 1.442 2.162 ... 94.42 95.15 95.87 96.59, '2': <xarray.DataArray 'array-dd59cfa6aeac755c5fd9b53fd121f3b8' (c: 2, z: 236,
+                                                            y: 68, x: 67)> Size: 4MB
 dask.array<array, shape=(2, 236, 68, 67), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
 Coordinates:
-  * c        (c) float64 0.0 1.0
-  * z        (z) float64 0.0 0.5002 1.0 1.501 2.001 ... 116.0 116.5 117.0 117.5
-  * y        (y) float64 0.0 1.442 2.883 4.325 5.766 ... 92.26 93.7 95.15 96.59
-  * x        (x) float64 0.0 1.442 2.883 4.325 5.766 ... 90.82 92.26 93.7 95.15}
+  * c        (c) float64 16B 0.0 1.0
+  * z        (z) float64 2kB 0.0 0.5002 1.0 1.501 ... 116.0 116.5 117.0 117.5
+  * y        (y) float64 544B 0.0 1.442 2.883 4.325 ... 92.26 93.7 95.15 96.59
+  * x        (x) float64 536B 0.0 1.442 2.883 4.325 ... 90.82 92.26 93.7 95.15}
 """
 ```
 
@@ -88,7 +88,7 @@ array_z = zarr.open_array("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062
 array_x = read_multiscale_array(array_z)
 print(array_x)
 """
-<xarray.DataArray (c: 2, z: 236, y: 68, x: 67)>
+<xarray.DataArray (c: 2, z: 236, y: 68, x: 67)> Size: 4MB
 array([[[[28, 10,  9, ...,  9,  9,  9],
          [10,  9,  9, ...,  9, 23, 10],
          [ 9,  9,  9, ...,  8, 93,  9],
@@ -131,10 +131,10 @@ array([[[[28, 10,  9, ...,  9,  9,  9],
          [28, 27, 28, ..., 39, 28, 28],
          [28, 28, 28, ..., 27, 28, 28]]]], dtype=uint16)
 Coordinates:
-  * c        (c) float64 0.0 1.0
-  * z        (z) float64 0.0 0.5002 1.0 1.501 2.001 ... 116.0 116.5 117.0 117.5
-  * y        (y) float64 0.0 1.442 2.883 4.325 5.766 ... 92.26 93.7 95.15 96.59
-  * x        (x) float64 0.0 1.442 2.883 4.325 5.766 ... 90.82 92.26 93.7 95.15
+  * c        (c) float64 16B 0.0 1.0
+  * z        (z) float64 2kB 0.0 0.5002 1.0 1.501 ... 116.0 116.5 117.0 117.5
+  * y        (y) float64 544B 0.0 1.442 2.883 4.325 ... 92.26 93.7 95.15 96.59
+  * x        (x) float64 536B 0.0 1.442 2.883 4.325 ... 90.82 92.26 93.7 95.15
 """
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/U.N. Owen/xarray-ome-ngff#readme"
-Issues = "https://github.com/U.N. Owen/xarray-ome-ngff/issues"
-Source = "https://github.com/U.N. Owen/xarray-ome-ngff"
+Documentation = "https://janeliascicomp.github.io/xarray-ome-ngff"
+Issues = "https://github.com/janeliascicomp/xarray-ome-ngff/issues"
+Source = "https://github.com/janeliascicomp/xarray-ome-ngff"
 
 [tool.hatch.version]
 path = "src/xarray_ome_ngff/__about__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,16 +16,16 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
+  "zarr<3.0.0",
   "xarray >= 2023.2.0",
   "pydantic-ome-ngff >= 0.5.0",
-  "pint >= 0.20.1",
+  "pint >= 0.24",
   "pydantic >= 2.0.0, <3",
   "dask >= 2022.3.0"
 ]
@@ -38,15 +38,18 @@ Source = "https://github.com/U.N. Owen/xarray-ome-ngff"
 [tool.hatch.version]
 path = "src/xarray_ome_ngff/__about__.py"
 
-[tool.hatch.env.test]
+[tool.hatch.envs.test]
 dependencies = [
   "pytest == 7.2.1",
   "pytest-cov",
   "s3fs",
-  "pytest-examples >= 0.0.9"]
+  "pytest-examples >= 0.0.9",
+  "requests",
+  "aiohttp",
+  ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11"]
+python = ["3.10", "3.11"]
 
 [tool.hatch.envs.test.scripts]
 run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,60 +1,79 @@
-[tool.poetry]
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
 name = "xarray-ome-ngff"
-version = "2.2.0"
-description = "xarray and ome-ngff"
-authors = ["Davis Vann Bennett <davis.v.bennett@gmail.com>"]
+dynamic = ["version"]
+description = 'Xarray and OME-NGFF'
 readme = "README.md"
-packages = [{include = "xarray_ome_ngff", from="src"}]
-
-[tool.poetry.dependencies]
-python = "^3.9"
-xarray = "^2023.2.0"
-pydantic-ome-ngff = "^0.5.0"
-pint = "^0.20.1"
-pydantic = "^2.0.0"
-dask = "^2024.3.1"
-
-[tool.poetry.extras]
-dask = ["dask"]
-
-[tool.poetry.group.dev.dependencies]
-pytest = "^7.2.1"
-pre-commit = "^3.0.4"
-mypy = "^1.1.1"
-pytest-cov = "^4.0.0"
-
-[tool.poetry.group.docs.dependencies]
-mkdocs-material = "^9.5.15"
-mkdocstrings = {extras = ["python"], version = "^0.24.0"}
-pytest-examples = "^0.0.9"
-requests = "^2.31.0"
-aiohttp = "^3.9.3"
-
-[tool.mypy]
-plugins = [
-  "pydantic.mypy"
+requires-python = ">=3.9"
+license = "MIT"
+keywords = ["ngff", "xarray"]
+authors = [
+  { name = "Davis Vann Bennett", email = "davis.v.bennett@gmail.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+]
+dependencies = [
+  "xarray >= 2023.2.0",
+  "pydantic-ome-ngff >= 0.5.0",
+  "pint >= 0.20.1",
+  "pydantic >= 2.0.0, <3",
+  "dask >= 2022.3.0"
 ]
 
-follow_imports = "silent"
-warn_redundant_casts = true
-warn_unused_ignores = true
-disallow_any_generics = true
-check_untyped_defs = true
-no_implicit_reexport = true
+[project.urls]
+Documentation = "https://github.com/U.N. Owen/xarray-ome-ngff#readme"
+Issues = "https://github.com/U.N. Owen/xarray-ome-ngff/issues"
+Source = "https://github.com/U.N. Owen/xarray-ome-ngff"
 
-# for strict mypy: (this is the tricky one :-))
-disallow_untyped_defs = true
+[tool.hatch.version]
+path = "src/xarray_ome_ngff/__about__.py"
 
-[tool.pydantic-mypy]
-init_forbid_extra = true
-init_typed = true
-warn_required_dynamic_aliases = true
+[tool.hatch.env.test]
+dependencies = [
+  "pytest == 7.2.1",
+  "pytest-cov",
+  "s3fs",
+  "pytest-examples >= 0.0.9"]
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[[tool.hatch.envs.test.matrix]]
+python = ["3.9", "3.10", "3.11"]
 
-[tool.ruff]
-lint.select = [
-    "I",  # isort formatting.
+[tool.hatch.envs.test.scripts]
+run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests"
+run = "run-coverage --no-cov"
+
+[tool.hatch.envs.types]
+extra-dependencies = [
+  "mypy>=1.0.0",
+]
+[tool.hatch.envs.types.scripts]
+check = "mypy --install-types --non-interactive {args:src/xarray_ome_ngff tests}"
+
+[tool.coverage.run]
+source_pkgs = ["xarray_ome_ngff", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/xarray_ome_ngff/__about__.py",
+]
+
+[tool.coverage.paths]
+xarray_ome_ngff = ["src/xarray_ome_ngff", "*/xarray-ome-ngff/src/xarray_ome_ngff"]
+tests = ["tests", "*/xarray-ome-ngff/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
 ]

--- a/src/xarray_ome_ngff/__about__.py
+++ b/src/xarray_ome_ngff/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024-present U.N. Owen <void@some.where>
+#
+# SPDX-License-Identifier: MIT
+__version__ = "2.2.0"

--- a/src/xarray_ome_ngff/__about__.py
+++ b/src/xarray_ome_ngff/__about__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-present U.N. Owen <void@some.where>
+# SPDX-FileCopyrightText: 2024-present Howard Hughes Medical Institute
 #
 # SPDX-License-Identifier: MIT
 __version__ = "2.2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from zarr.storage import DirectoryStore, MemoryStore
+from zarr.storage import DirectoryStore, MemoryStore, FSStore
 
 
 @pytest.fixture(scope="function")
@@ -8,5 +8,6 @@ def store(request, tmpdir):
         return MemoryStore()
     elif request.param == "directory_store":
         return DirectoryStore(str(tmpdir))
-    else:
-        assert False
+    elif request.param == "fsstore_local":
+        return FSStore(str(tmpdir))
+    raise AssertionError


### PR DESCRIPTION
fix a bug that prevented getting the parent node of an array or group with fsspec-backed store classes