### PR TITLE
support `overwrite` keyword argument when creating a multiscale group

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ default_language_version:
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.3
+    rev: v0.6.3
     hooks:
     # Run the linter.
     - id: ruff
@@ -15,19 +15,14 @@ repos:
     # Run the formatter.
     - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     - id: check-yaml
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.11.2
     hooks:
       - id: mypy
-        files: zarr
-        args: []
-        additional_dependencies:
-          - types-redis
-          - types-setuptools

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Coordinates:
   * c        (c) float64 16B 0.0 1.0
   * z        (z) float64 2kB 0.0 0.5002 1.0 1.501 ... 116.0 116.5 117.0 117.5
   * y        (y) float64 1kB 0.0 0.7208 1.442 2.162 ... 95.87 96.59 97.31 98.03
-  * x        (x) float64 1kB 0.0 0.7208 1.442 2.162 ... 94.42 95.15 95.87 96.59, '2': <xarray.DataArray 'array-8ee9747fd29b7556b4c5c9cf609792da' (c: 2, z: 236,
+  * x        (x) float64 1kB 0.0 0.7208 1.442 2.162 ... 94.42 95.15 95.87 96.59, '2': <xarray.DataArray 'array-dd59cfa6aeac755c5fd9b53fd121f3b8' (c: 2, z: 236,
                                                             y: 68, x: 67)> Size: 4MB
 dask.array<array, shape=(2, 236, 68, 67), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
 Coordinates:

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Coordinates:
   * c        (c) float64 16B 0.0 1.0
   * z        (z) float64 2kB 0.0 0.5002 1.0 1.501 ... 116.0 116.5 117.0 117.5
   * y        (y) float64 1kB 0.0 0.7208 1.442 2.162 ... 95.87 96.59 97.31 98.03
-  * x        (x) float64 1kB 0.0 0.7208 1.442 2.162 ... 94.42 95.15 95.87 96.59, '2': <xarray.DataArray 'array-dd59cfa6aeac755c5fd9b53fd121f3b8' (c: 2, z: 236,
+  * x        (x) float64 1kB 0.0 0.7208 1.442 2.162 ... 94.42 95.15 95.87 96.59, '2': <xarray.DataArray 'array-8ee9747fd29b7556b4c5c9cf609792da' (c: 2, z: 236,
                                                             y: 68, x: 67)> Size: 4MB
 dask.array<array, shape=(2, 236, 68, 67), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
 Coordinates:
@@ -173,9 +173,6 @@ print(group.attrs.asdict())
     'multiscales': (
         {
             'version': '0.4',
-            'name': None,
-            'type': None,
-            'metadata': None,
             'datasets': (
                 {
                     'path': 's0',
@@ -196,7 +193,6 @@ print(group.attrs.asdict())
                 {'name': 'x', 'type': 'space', 'unit': 'meter'},
                 {'name': 'y', 'type': 'space', 'unit': 'meter'},
             ),
-            'coordinateTransformations': None,
         },
     )
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
   "zarr<3.0.0",
   "xarray >= 2023.2.0",
-  "pydantic-ome-ngff == 0.5.3",
+  "pydantic-ome-ngff == 0.6.0",
   "pint >= 0.24",
   "pydantic >= 2.0.0, <3",
   "dask >= 2022.3.0"
@@ -45,6 +45,7 @@ dependencies = [
   "pytest-examples >= 0.0.9",
   "requests",
   "aiohttp",
+  "dask"
   ]
 
 [[tool.hatch.envs.test.matrix]]

--- a/src/xarray_ome_ngff/__init__.py
+++ b/src/xarray_ome_ngff/__init__.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from importlib.metadata import version as _version
 from zarr.storage import BaseStore
 from xarray_ome_ngff.array_wrap import (
     ArrayWrapperSpec,
-    BaseArrayWrapper,
     DaskArrayWrapper,
     ZarrArrayWrapper,
 )
@@ -13,7 +12,7 @@ from xarray_ome_ngff.core import NGFF_VERSIONS
 if TYPE_CHECKING:
     from typing import Literal
     from pydantic_ome_ngff.v04.multiscale import Group as MultiscaleGroupV04
-
+from numcodecs.abc import Codec
 from xarray import DataArray
 import zarr
 from xarray_ome_ngff.v04 import multiscale as multiscale_v04
@@ -24,7 +23,9 @@ __version__ = _version(__name__)
 # todo: remove the need to specify the version for reading
 def read_multiscale_group(
     group: zarr.Group,
-    array_wrapper: BaseArrayWrapper | ArrayWrapperSpec = ZarrArrayWrapper(),
+    array_wrapper: ZarrArrayWrapper
+    | DaskArrayWrapper
+    | ArrayWrapperSpec = ZarrArrayWrapper(),
     ngff_version: Literal["0.4"] = "0.4",
     **kwargs,
 ) -> dict[str, DataArray]:
@@ -39,7 +40,7 @@ def read_multiscale_group(
     ----------
     group: zarr.Group
         A handle for the Zarr group that contains the OME-NGFF metadata.
-    array_wrapper: BaseArrayWrapper | ArrayWrapperSpec, default is ZarrArrayWrapper
+    array_wrapper: ZarrArrayWrapper | DaskArrayWrapper | ArrayWrapperSpec, default = ZarrArrayWrapper
         Either an object that implements `BaseArrayWrapper`, or a dict model of such a subclass,
         which will be resolved to an object implementing `BaseArrayWrapper`. This object has a
         `wrap` method that takes an instance of `zarr.Array` and returns another array-like object.
@@ -60,7 +61,9 @@ def read_multiscale_group(
 # todo: remove the need to specify the version for reading
 def read_multiscale_array(
     array: zarr.Array,
-    array_wrapper: BaseArrayWrapper | ArrayWrapperSpec = ZarrArrayWrapper(),
+    array_wrapper: ZarrArrayWrapper
+    | DaskArrayWrapper
+    | ArrayWrapperSpec = ZarrArrayWrapper(),
     ngff_version: Literal["0.4"] = "0.4",
     **kwargs,
 ) -> DataArray:
@@ -92,6 +95,9 @@ def model_multiscale_group(
     arrays: dict[str, DataArray],
     transform_precision: int | None = None,
     ngff_version: Literal["0.4"] = "0.4",
+    chunks: tuple[int, ...] | tuple[tuple[int, ...]] | Literal["auto"] = "auto",
+    compressor: Codec | None = multiscale_v04.DEFAULT_COMPRESSOR,
+    fill_value: Any = 0,
 ) -> MultiscaleGroupV04:
     """
     Create a model of an OME-NGFF multiscale group from a dict of `xarray.DataArray`.
@@ -108,12 +114,26 @@ def model_multiscale_group(
         x decimal places using `numpy.round(transform, x)`.
     ngff_version: Literal["0.4"]
         The OME-NGFF version to use.
+    chunks: tuple[int] | tuple[tuple[int, ...]] | Literal["auto"], default = "auto"
+        The chunks for the arrays in the multiscale group.
+        If the string "auto" is provided, each array will have chunks set to the zarr-python default
+        value, which depends on the shape and dtype of the array.
+        If a single sequence of ints is provided, then this defines the chunks for all arrays.
+        If a sequence of sequences of ints is provided, then this defines the chunks for each array.
+    compressor: Codec | None, default = numcodecs.ZStd.
+        The compressor to use for the arrays. Default is `numcodecs.ZStd`.
+    fill_value: Any
+        The fill value for the Zarr arrays.
     """
     if ngff_version not in NGFF_VERSIONS:
         raise ValueError(f"Unsupported NGFF version: {ngff_version}")
     if ngff_version == "0.4":
         return multiscale_v04.model_multiscale_group(
-            arrays=arrays, transform_precision=transform_precision
+            arrays=arrays,
+            transform_precision=transform_precision,
+            compressor=compressor,
+            chunks=chunks,
+            fill_value=fill_value,
         )
 
 
@@ -124,6 +144,9 @@ def create_multiscale_group(
     arrays: dict[str, DataArray],
     transform_precision: int | None = None,
     ngff_version: Literal["0.4"] = "0.4",
+    chunks: tuple[int, ...] | tuple[tuple[int, ...]] | Literal["auto"] = "auto",
+    compressor: Codec | None = multiscale_v04.DEFAULT_COMPRESSOR,
+    fill_value: Any = 0,
 ) -> MultiscaleGroupV04:
     """
     store: zarr.storage.BaseStore
@@ -138,6 +161,16 @@ def create_multiscale_group(
         x decimal places using `numpy.round(transform, x)`.
     ngff_version: Literal["0.4"]
         The OME-NGFF version to use.
+    chunks: tuple[int] | tuple[tuple[int, ...]] | Literal["auto"], default = "auto"
+        The chunks for the arrays in the multiscale group.
+        If the string "auto" is provided, each array will have chunks set to the zarr-python default
+        value, which depends on the shape and dtype of the array.
+        If a single sequence of ints is provided, then this defines the chunks for all arrays.
+        If a sequence of sequences of ints is provided, then this defines the chunks for each array.
+    compressor: Codec | None, default = numcodecs.ZStd.
+        The compressor to use for the arrays. Default is `numcodecs.ZStd`.
+    fill_value: Any
+        The fill value for the Zarr arrays.
     """
     if ngff_version not in NGFF_VERSIONS:
         raise ValueError(f"Unsupported NGFF version: {ngff_version}")
@@ -147,6 +180,9 @@ def create_multiscale_group(
             path=path,
             arrays=arrays,
             transform_precision=transform_precision,
+            compressor=compressor,
+            chunks=chunks,
+            fill_value=fill_value,
         )
 
 

--- a/src/xarray_ome_ngff/__init__.py
+++ b/src/xarray_ome_ngff/__init__.py
@@ -52,7 +52,9 @@ def read_multiscale_group(
     if ngff_version not in NGFF_VERSIONS:
         raise ValueError(f"Unsupported NGFF version: {ngff_version}")
     if ngff_version == "0.4":
-        return multiscale_v04.read_group(group, array_wrapper=array_wrapper, **kwargs)
+        return multiscale_v04.read_multiscale_group(
+            group, array_wrapper=array_wrapper, **kwargs
+        )
 
 
 # todo: remove the need to specify the version for reading
@@ -80,7 +82,9 @@ def read_multiscale_array(
     if ngff_version not in NGFF_VERSIONS:
         raise ValueError(f"Unsupported NGFF version: {ngff_version}")
     if ngff_version == "0.4":
-        return multiscale_v04.read_array(array, array_wrapper=array_wrapper, **kwargs)
+        return multiscale_v04.read_multiscale_array(
+            array, array_wrapper=array_wrapper, **kwargs
+        )
 
 
 def model_multiscale_group(
@@ -108,7 +112,7 @@ def model_multiscale_group(
     if ngff_version not in NGFF_VERSIONS:
         raise ValueError(f"Unsupported NGFF version: {ngff_version}")
     if ngff_version == "0.4":
-        return multiscale_v04.model_group(
+        return multiscale_v04.model_multiscale_group(
             arrays=arrays, transform_precision=transform_precision
         )
 
@@ -138,7 +142,7 @@ def create_multiscale_group(
     if ngff_version not in NGFF_VERSIONS:
         raise ValueError(f"Unsupported NGFF version: {ngff_version}")
     if ngff_version == "0.4":
-        return multiscale_v04.create_group(
+        return multiscale_v04.create_multiscale_group(
             store=store,
             path=path,
             arrays=arrays,


### PR DESCRIPTION
A few other changes in here:
- update `pydantic-ome-ngff` to 0.6.0
- rename `create_group` to `create_multiscale_group`, and similarly for `model_group`, `read_group`, etc
- add some docstrings