### PR TITLE
add overwrite kwarg to the top-level create_multiscale_group routine

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,29 +26,37 @@ the attributes of the Zarr group to generate coordinates for each `DataArray`.
 import zarr
 from xarray_ome_ngff import read_multiscale_group, DaskArrayWrapper
 group = zarr.open_group("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr")
-
 # this ensures that we create a Dask array, which gives us lazy loading
 array_wrapper = DaskArrayWrapper(chunks=10)
 arrays = read_multiscale_group(group, array_wrapper=array_wrapper)
 print(arrays)
 """
-{'0': <xarray.DataArray 'array-dc1746969a43c4e18b4a861ae8a5b5e5' (c: 2, z: 236,
-                                                            y: 275, x: 271)> Size: 70MB
-dask.array<array, shape=(2, 236, 275, 271), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
+{'0': <xarray.DataArray 'https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr/0' (
+                                                                                           c: 2,
+                                                                                           z: 236,
+                                                                                           y: 275,
+                                                                                           x: 271)> Size: 70MB
+dask.array<https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr/0, shape=(2, 236, 275, 271), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
 Coordinates:
   * c        (c) float64 16B 0.0 1.0
   * z        (z) float64 2kB 0.0 0.5002 1.0 1.501 ... 116.0 116.5 117.0 117.5
   * y        (y) float64 2kB 0.0 0.3604 0.7208 1.081 ... 97.67 98.03 98.39 98.75
-  * x        (x) float64 2kB 0.0 0.3604 0.7208 1.081 ... 96.23 96.59 96.95 97.31, '1': <xarray.DataArray 'array-9663bb2b4241268352500eb4e3bef581' (c: 2, z: 236,
-                                                            y: 137, x: 135)> Size: 17MB
-dask.array<array, shape=(2, 236, 137, 135), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
+  * x        (x) float64 2kB 0.0 0.3604 0.7208 1.081 ... 96.23 96.59 96.95 97.31, '1': <xarray.DataArray 'https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr/1' (
+                                                                                           c: 2,
+                                                                                           z: 236,
+                                                                                           y: 137,
+                                                                                           x: 135)> Size: 17MB
+dask.array<https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr/1, shape=(2, 236, 137, 135), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
 Coordinates:
   * c        (c) float64 16B 0.0 1.0
   * z        (z) float64 2kB 0.0 0.5002 1.0 1.501 ... 116.0 116.5 117.0 117.5
   * y        (y) float64 1kB 0.0 0.7208 1.442 2.162 ... 95.87 96.59 97.31 98.03
-  * x        (x) float64 1kB 0.0 0.7208 1.442 2.162 ... 94.42 95.15 95.87 96.59, '2': <xarray.DataArray 'array-dd59cfa6aeac755c5fd9b53fd121f3b8' (c: 2, z: 236,
-                                                            y: 68, x: 67)> Size: 4MB
-dask.array<array, shape=(2, 236, 68, 67), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
+  * x        (x) float64 1kB 0.0 0.7208 1.442 2.162 ... 94.42 95.15 95.87 96.59, '2': <xarray.DataArray 'https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr/2' (
+                                                                                           c: 2,
+                                                                                           z: 236,
+                                                                                           y: 68,
+                                                                                           x: 67)> Size: 4MB
+dask.array<https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr/2, shape=(2, 236, 68, 67), dtype=uint16, chunksize=(2, 10, 10, 10), chunktype=numpy.ndarray>
 Coordinates:
   * c        (c) float64 16B 0.0 1.0
   * z        (z) float64 2kB 0.0 0.5002 1.0 1.501 ... 116.0 116.5 117.0 117.5

--- a/src/xarray_ome_ngff/__init__.py
+++ b/src/xarray_ome_ngff/__init__.py
@@ -11,7 +11,7 @@ from xarray_ome_ngff.core import NGFF_VERSIONS
 
 if TYPE_CHECKING:
     from typing import Literal
-    from pydantic_ome_ngff.v04.multiscale import Group as MultiscaleGroupV04
+    from pydantic_ome_ngff.v04.multiscale import MultiscaleGroup as MultiscaleGroupV04
 from numcodecs.abc import Codec
 from xarray import DataArray
 import zarr
@@ -147,6 +147,7 @@ def create_multiscale_group(
     chunks: tuple[int, ...] | tuple[tuple[int, ...]] | Literal["auto"] = "auto",
     compressor: Codec | None = multiscale_v04.DEFAULT_COMPRESSOR,
     fill_value: Any = 0,
+    overwrite: bool = False,
 ) -> MultiscaleGroupV04:
     """
     store: zarr.storage.BaseStore
@@ -183,6 +184,7 @@ def create_multiscale_group(
             compressor=compressor,
             chunks=chunks,
             fill_value=fill_value,
+            overwrite=overwrite,
         )
 
 

--- a/src/xarray_ome_ngff/core.py
+++ b/src/xarray_ome_ngff/core.py
@@ -45,6 +45,8 @@ def get_store_url(store: BaseStore) -> str:
             store_path = store.path
         return f"{protocol}://{store_path}"
     else:
+        if isinstance(store, zarr.MemoryStore):
+            return f"memory://{id(store)}/"
         msg = (
             f"The store associated with this object has type {type(store)}, which "
             "cannot be resolved to a url"

--- a/tests/test_v04.py
+++ b/tests/test_v04.py
@@ -7,6 +7,7 @@ from xarray import DataArray
 import numpy as np
 from typing import Literal, Optional, Any
 from xarray_ome_ngff.array_wrap import (
+    ArrayWrapperSpec,
     DaskArrayWrapper,
     DaskArrayWrapperSpec,
     ZarrArrayWrapper,
@@ -138,7 +139,7 @@ def pyramid(request) -> tuple[DataArray, DataArray, DataArray]:
 
     coarsen_kwargs = {**{dim: 2 for dim in data.dims}, "boundary": "trim"}
     multi = (data, data.coarsen(**coarsen_kwargs).mean())
-    multi += (multi[-1].coarsen(**coarsen_kwargs).mean(),) # type: ignore
+    multi += (multi[-1].coarsen(**coarsen_kwargs).mean(),)  # type: ignore
     return multi
 
 
@@ -377,11 +378,7 @@ def test_read_create_group(
     store: BaseStore,
     paths: tuple[str, str, str],
     pyramid: tuple[DataArray, DataArray, DataArray],
-    array_wrapper: (
-        ZarrArrayWrapper
-        | DaskArrayWrapper
-        | ArrayWrapperSpec
-    ),
+    array_wrapper: (ZarrArrayWrapper | DaskArrayWrapper | ArrayWrapperSpec),
     chunks: int | Literal["auto"],
     compressor: None | Zstd,
     fill_value: Literal[0, 1],


### PR DESCRIPTION
- adds `overwrite` to top-level `create_multiscale_group`
- changes the dask array wrapper to enable deterministic names for arrays, which resolves the doctests that were failing